### PR TITLE
ci: back to dryRun releases again

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -3,6 +3,8 @@ branches:
   - name: main
 # TODO: Remove; Might be useful to have some debug when attempting the first releases
 debug: true
+# TODO: Remove; Attempt a dry run release before a real one
+dryRun: true
 plugins:
   - "@semantic-release/commit-analyzer"
   - "@semantic-release/release-notes-generator"


### PR DESCRIPTION
Back to dryRun releases to experiment with CI releasing.

This reverts commit 51a058d9e06c824425937581dbb8a5edb3a49c64.

